### PR TITLE
Improvements in headers on auth Go example

### DIFF
--- a/go/auth/auth.go
+++ b/go/auth/auth.go
@@ -74,9 +74,10 @@ func Callback(clientID string, clientSecret string, redirectURI string) http.Han
 			return
 		}
 
-		var data = clientID + clientSecret
+		var data = clientID + ":" + clientSecret
 		dataEncoded := b64.StdEncoding.EncodeToString([]byte(data))
 		req.Header.Set("Authorization", "Basic "+dataEncoded)
+		req.Header.Set("Content-Type", "application/json")
 
 		client := &http.Client{Timeout: time.Second * 2}
 		resp, err := client.Do(req)


### PR DESCRIPTION
- Fix encoded pattern adding `:` between clientID and clientSecret
- Add new header in request to API: `Content-Type: application/json`